### PR TITLE
Feat/deploy api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/database.json ./database.json
+COPY --from=build /app/migrations ./migrations
 COPY --from=build /app/dist ./dist
 CMD ["node", "dist/index.js"]

--- a/docker-compose.e2e.ci.yml
+++ b/docker-compose.e2e.ci.yml
@@ -26,7 +26,7 @@ services:
     environment:
       WAIT_HOSTS: postgres:5432, api:9002
       WAIT_LOGGER_LEVEL: "error"
-    command: 'sh -c "/wait && npx db-migrate up && npx jest --config jest.e2e.config.js -i"'
+    command: 'sh -c "/wait && npx jest --config jest.e2e.config.js -i"'
     links:
       - postgres
       - api

--- a/docker-compose.e2e.local.yml
+++ b/docker-compose.e2e.local.yml
@@ -14,7 +14,7 @@ services:
       PG_USER: root
       PG_PASS: root
       PG_DB: todos
-    command: 'sh -c "/wait && npx db-migrate up && npx nodemon src/index.ts"'
+    command: 'sh -c "/wait && npx nodemon src/index.ts"'
     volumes:
       - ./src:/app/src
     links:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "docker compose -f docker-compose.base.yml -f docker-compose.dev.yml up api",
+    "start": "node dist/index.js",
+    "dev": "docker compose -f docker-compose.base.yml -f docker-compose.dev.yml up api",
     "lint": "eslint . --ext .ts",
     "test": "jest --no-cache --passWithNoTests",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' '__tests__/**/*.ts' --write",

--- a/src/infrastructure/postgres/index.ts
+++ b/src/infrastructure/postgres/index.ts
@@ -1,4 +1,5 @@
 import * as postgres from "pg";
+import DBMigrate from "db-migrate";
 import { inject, injectable, singleton } from "tsyringe";
 import { AppConfiguration } from "../../tools/config";
 import { Logger } from "../../tools/logger";
@@ -27,6 +28,12 @@ export class PostgresPool {
     const client = await this.pool.connect();
     await client.query("SELECT NOW()");
     client.release();
+
+    // Run migrations
+    const dbMigrate = DBMigrate.getInstance(true, {
+      env: this.configuration.getAppConfig().nodeEnv === "production" ? "kubernetes" : "localKube"
+    });
+    await dbMigrate.up();
   }
 
   async getClient(): Promise<postgres.PoolClient> {


### PR DESCRIPTION
### Changes
- `db-migrate up` is executed at runtime instead of being a shell command
- Change `npm run start` and `npm run dev` so that it works with Heroku

Closes #16 