### PR TITLE
Chore/api specs rate limit

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,18 +38,16 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/todo"
+                  $ref: "#/components/schemas/Todo"
               example:
                 - uuid: 3d780d09-c520-4817-b430-ce849bcc5423
                   ownerUuid: 535d6711-2ec0-4ba7-9f34-3d13f25de822
                   title: Groceries
                   state: ACTIVE
         "400":
-          description: Request badly formatted
-          content:
-            "application/json":
-              schema:
-                $ref: "#/components/schemas/error"
+          $ref: "#/components/responses/BadRequest"
+        "429":
+          $ref: "#/components/responses/RateLimited"
     post:
       summary: Create a new todo
       description: Create a new todo
@@ -61,21 +59,21 @@ paths:
         content:
           "application/json":
             schema:
-              $ref: "#/components/schemas/todo"
+              $ref: "#/components/schemas/Todo"
       responses:
         "200":
           description: Successfully created a new todo
           content:
             "application/json":
               schema:
-                $ref: "#/components/schemas/todo"
+                $ref: "#/components/schemas/Todo"
+          links:
+            GetTodoByUuid:
+              $ref: "#/components/links/GetTodoByUuid"
         "400":
-          description: Request badly formatted
-          content:
-            "application/json":
-              schema:
-                $ref: "#/components/schemas/error"
-
+          $ref: "#/components/responses/BadRequest"
+        "429":
+          $ref: "#/components/responses/RateLimited"
   /v1/todos/{todoUuid}:
     get:
       summary: Get a todo
@@ -100,15 +98,13 @@ paths:
           content:
             "application/json":
               schema:
-                $ref: "#/components/schemas/todo"
+                $ref: "#/components/schemas/Todo"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "404":
           description: Couldn't find the todo with the provided uuid
-        "400":
-          description: Request badly formatted
-          content:
-            "application/json":
-              schema:
-                $ref: "#/components/schemas/error"
+        "429":
+          $ref: "#/components/responses/RateLimited"
     put:
       summary: Update a todo
       description: Update a todo by providing its uuid and the updated todo content
@@ -131,20 +127,18 @@ paths:
         content:
           "application/json":
             schema:
-              $ref: "#/components/schemas/todo"
+              $ref: "#/components/schemas/Todo"
       responses:
         "200":
           description: Successful response
           content:
             "application/json":
               schema:
-                $ref: "#/components/schemas/todo"
+                $ref: "#/components/schemas/Todo"
         "400":
-          description: Request badly formatted
-          content:
-            "application/json":
-              schema:
-                $ref: "#/components/schemas/error"
+          $ref: "#/components/responses/BadRequest"
+        "429":
+          $ref: "#/components/responses/RateLimited"
     delete:
       summary: Delete a todo
       description: Delete a todo by providing its uuid
@@ -166,11 +160,7 @@ paths:
         "204":
           description: Successful response
         "400":
-          description: Request badly formatted
-          content:
-            "application/json":
-              schema:
-                $ref: "#/components/schemas/error"
+          $ref: "#/components/responses/BadRequest"
 
   /ready:
     get:
@@ -194,9 +184,10 @@ paths:
           description: Service is healthy
         "503":
           description: Service isn't healthy
+
 components:
   schemas:
-    todo:
+    Todo:
       type: object
       properties:
         uuid:
@@ -228,7 +219,7 @@ components:
         ownerUuid: 535d6711-2ec0-4ba7-9f34-3d13f25de822
         title: Groceries
         state: ACTIVE
-    error:
+    Error:
       type: object
       properties:
         statusCode:
@@ -244,3 +235,25 @@ components:
         statusCode: 400
         error: "Bad Request"
         message: "querystring must have required property 'ownerUuid'"
+
+  responses:
+    BadRequest:
+      description: Request badly formatted
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/Error"
+    RateLimited:
+      description: Too many requests were sent
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/Error"
+  links:
+    GetTodoByUuid:
+      operationId: getTodo
+      parameters:
+        todoUuid: "$response.body#/uuid"
+      description: >
+        The `uuid` value returned in the response can be used as
+        the `todoUuid` parameter in `GET /todos/{todoUuid}`.

--- a/src/rest/middlewares/rateLimit.ts
+++ b/src/rest/middlewares/rateLimit.ts
@@ -33,7 +33,7 @@ export class RateLimitMiddleware {
     if (counter > this.configuration.getAppConfig().apiMaxRequestsPerTTL) {
       this.logger.logger.error(`IP ${externalIP} is sending too many requests`);
       const error = new Error("Rate limited");
-      reply.status(403).send(error);
+      reply.status(429).send(error);
       throw error;
     }
   }


### PR DESCRIPTION
### Changes
- Rate limit now returns a 429 error as expected
- Updated api specs
  - Add RateLimited error
  - Add link from createTodo to getTodo
  - Refactor error response to `components/responses` (centralize definition)