### PR TITLE
build: remove db-migrate command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS dev
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
 COPY ./ ./
-CMD ["sh", "-c", "npx db-migrate up -e localKube && npx nodemon src/index.ts"]
+CMD ["sh", "-c", "npx nodemon src/index.ts"]
 
 FROM base AS build
 COPY ./ ./


### PR DESCRIPTION
### Changed
- Removed db-migrate usage from Dockerfile